### PR TITLE
Added Compatibility tests for ExportSpec struct

### DIFF
--- a/pkg/mcs/exportspec.go
+++ b/pkg/mcs/exportspec.go
@@ -79,8 +79,7 @@ func (err *CompatibilityError) Error() string {
 		return fmt.Sprintf("field %s conflicts with value in cluster %s",
 			err.field, err.clusterID)
 	}
-	return fmt.Sprintf("The same service has different %s in cluster %s",
-		err.field, err.clusterID)
+	return "the export refers to a different service and is incompatible"
 }
 
 func (err *CompatibilityError) Cause() string {
@@ -183,18 +182,28 @@ func (es *ExportSpec) IsPreferredOver(another *ExportSpec) bool {
 // @todo do we want to collect a map of the conflicting Global Properties?
 func (es *ExportSpec) IsCompatibleWith(another *ExportSpec) *CompatibilityError {
 	if es.Name != another.Name {
-		return &CompatibilityError{another.ClusterID, NameField}
+		return &CompatibilityError{
+			clusterID: another.ClusterID,
+			field:     NameField}
 	}
 	if es.Namespace != another.Namespace {
-		return &CompatibilityError{another.ClusterID, NamespaceField}
+		return &CompatibilityError{
+			clusterID: another.ClusterID,
+			field:     NamespaceField}
 	}
 
 	if es.Service.Type != another.Service.Type {
-		return &CompatibilityError{another.ClusterID, TypeField}
+		return &CompatibilityError{
+			clusterID: another.ClusterID,
+			field:     TypeField}
 	} else if es.Service.SessionAffinity != another.Service.SessionAffinity {
-		return &CompatibilityError{another.ClusterID, AffinityField}
+		return &CompatibilityError{
+			clusterID: another.ClusterID,
+			field:     AffinityField}
 	} else if !reflect.DeepEqual(es.Service.SessionAffinityConfig, another.Service.SessionAffinityConfig) {
-		return &CompatibilityError{another.ClusterID, AffinityConfigField}
+		return &CompatibilityError{
+			clusterID: another.ClusterID,
+			field:     AffinityConfigField}
 	}
 
 	ports := make(map[string]mcsv1a1.ServicePort, len(es.Service.Ports))
@@ -208,7 +217,9 @@ func (es *ExportSpec) IsCompatibleWith(another *ExportSpec) *CompatibilityError 
 		if !found {
 			continue
 		} else if !reflect.DeepEqual(current, other) {
-			return &CompatibilityError{another.ClusterID, PortField}
+			return &CompatibilityError{
+				clusterID: another.ClusterID,
+				field:     PortField}
 		}
 	}
 	return nil

--- a/pkg/mcs/exportspec.go
+++ b/pkg/mcs/exportspec.go
@@ -182,19 +182,19 @@ func (es *ExportSpec) IsPreferredOver(another *ExportSpec) bool {
 // false and the name of the conflicting field.
 // @todo do we want to collect a map of the conflicting Global Properties?
 func (es *ExportSpec) IsCompatibleWith(another *ExportSpec) *CompatibilityError {
+	if es.Name != another.Name {
+		return &CompatibilityError{another.ClusterID, NameField}
+	}
+	if es.Namespace != another.Namespace {
+		return &CompatibilityError{another.ClusterID, NamespaceField}
+	}
+
 	if es.Service.Type != another.Service.Type {
 		return &CompatibilityError{another.ClusterID, TypeField}
 	} else if es.Service.SessionAffinity != another.Service.SessionAffinity {
 		return &CompatibilityError{another.ClusterID, AffinityField}
 	} else if !reflect.DeepEqual(es.Service.SessionAffinityConfig, another.Service.SessionAffinityConfig) {
 		return &CompatibilityError{another.ClusterID, AffinityConfigField}
-	}
-
-	if es.Name != another.Name {
-		return &CompatibilityError{another.ClusterID, NameField}
-	}
-	if es.Namespace != another.Namespace {
-		return &CompatibilityError{another.ClusterID, NamespaceField}
 	}
 
 	ports := make(map[string]mcsv1a1.ServicePort, len(es.Service.Ports))

--- a/pkg/mcs/exportspec_test.go
+++ b/pkg/mcs/exportspec_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 var (
-	timeout      = int32(10)
-	otherTimeout = int32(11)
+	timeout = int32(10)
 
 	sample = mcs.ExportSpec{
 		//Truncate time to UTC time-zone with seconds resulotion in order to be compatible with k8s marshal returned time
@@ -201,6 +200,7 @@ func TestCompatibility(t *testing.T) {
 
 		"conflicting: affinity config": {spec: &sample, compatible: false, field: "affinity config",
 			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				otherTimeout := int32(11)
 				es.Service.SessionAffinityConfig = &corev1.SessionAffinityConfig{
 					ClientIP: &corev1.ClientIPConfig{
 						TimeoutSeconds: &otherTimeout,

--- a/pkg/mcs/exportspec_test.go
+++ b/pkg/mcs/exportspec_test.go
@@ -153,15 +153,43 @@ func TestCompatibility(t *testing.T) {
 		other      *mcs.ExportSpec
 		compatible bool
 		field      string
+		mutate     func(mcs.ExportSpec) *mcs.ExportSpec
 	}{
-		"compatible: empty": {spec: &mcs.ExportSpec{}, other: &mcs.ExportSpec{}, compatible: true},
-		/*
-			"compatible: identical":        {},
-			"compatible: local properties": {},
-			"conflicting: type":            {},
-			"conflicting: affinity":        {},
-			"conflicting: port":            {},
-		*/
+		"compatible: empty": {spec: &mcs.ExportSpec{}, compatible: true,
+			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				return &mcs.ExportSpec{}
+			}},
+
+		"compatible: identical": {spec: &sample, compatible: true,
+			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				return &es
+			}},
+
+		"compatible: local properties": {spec: &sample, compatible: true, //#TODO check if that whay Etai means. Does it
+			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				es.CreatedAt = metav1.NewTime(time.Now().UTC())
+				es.Namespace = "different_namepsace"
+				es.Name = "different_name"
+				return &es
+			}},
+
+		"conflicting: type": {spec: &sample, compatible: false, field: "type",
+			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				es.Service.Type = mcsv1a1.Headless
+				return &es
+			}},
+
+		"conflicting: affinity": {spec: &sample, compatible: false, field: "affinity",
+			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				es.Service.SessionAffinity = corev1.ServiceAffinityNone
+				return &es
+			}},
+
+		"conflicting: port": {spec: &sample, compatible: false, field: "ports",
+			mutate: func(es mcs.ExportSpec) *mcs.ExportSpec {
+				es.Service.Ports = append(es.Service.Ports, mcsv1a1.ServicePort{Port: 81, Name: "http", Protocol: corev1.ProtocolTCP})
+				return &es
+			}},
 	}
 
 	assertions := require.New(t)
@@ -169,9 +197,15 @@ func TestCompatibility(t *testing.T) {
 	for name, test := range testcases {
 		t.Logf("Running test case %s", name)
 
-		compatible, field := test.spec.IsCompatibleWith(test.other)
-		assertions.Equal(test.compatible, compatible)
-		assertions.Equal(test.field, field, "unexpected field conflict detected")
+		other := test.mutate(*test.spec)
+		err := test.spec.IsCompatibleWith(other)
+
+		if test.compatible {
+			assertions.Nil(err)
+		} else {
+			assertions.Error(err)
+			assertions.NotEqual("", err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
 Added different Compatibility tests for the ExportSpec struct

Changed the return value of IsCompatibleWith in exportspec.go to an error-struct
type contains the field that conflicts and the other cluster's id.