### PR TITLE
fix typos and add missing import and license

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6
 	github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1
 	github.com/uw-labs/lichen v0.1.5

--- a/pkg/mcs/doc.go
+++ b/pkg/mcs/doc.go
@@ -1,4 +1,21 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 // Package mcs provides utilities and extensions for Kubernetes Multi-cluster
-// Services API as defined by KEP 1645. 
+// Services API as defined by KEP 1645.
 // (https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api)
 package mcs

--- a/pkg/mcs/exportspec.go
+++ b/pkg/mcs/exportspec.go
@@ -1,3 +1,20 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package mcs
 
 import (
@@ -124,11 +141,11 @@ func (es *ExportSpec) UnmarshalObjectMeta(md *metav1.ObjectMeta) error {
 	return json.Unmarshal([]byte(value), es)
 }
 
-// IsPrefferredOver determines if this ExportSpec has precedence over the given
+// IsPreferredOver determines if this ExportSpec has precedence over the given
 // ExportSpec. This is based on the conflict resolution specification set in the
 // KEP (i.e.,earliest creation time wins), extended for consistency in the case
 // where exports are created at the exact same time.
-func (es *ExportSpec) IsPrefferredOver(another *ExportSpec) bool {
+func (es *ExportSpec) IsPreferredOver(another *ExportSpec) bool {
 	if es.CreatedAt == another.CreatedAt {
 		return es.ClusterID <= another.ClusterID
 	}

--- a/pkg/mcs/exportspec_test.go
+++ b/pkg/mcs/exportspec_test.go
@@ -1,3 +1,20 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package mcs_test
 
 import (
@@ -191,9 +208,9 @@ func TestConflictResolutionCriteria(t *testing.T) {
 	for name, test := range testcases {
 		t.Logf("Running test case %s", name)
 
-		preferred := test.spec.IsPrefferredOver(test.other)
+		preferred := test.spec.IsPreferredOver(test.other)
 		assertions.True(test.preferred == preferred || test.spec == test.other)
-		reversed := test.other.IsPrefferredOver(test.spec)
+		reversed := test.other.IsPreferredOver(test.spec)
 		assertions.True(preferred == !reversed || test.spec == test.other)
 	}
 }


### PR DESCRIPTION
Previous PR was incomplete:

- missing an import (for `testify`)
- license missing in new files
- had a typo (double `f` in preferred).

Signed-off-by: Etai Lev Ran <etail@il.ibm.com>

